### PR TITLE
SAS token support

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,24 +51,25 @@ $ bundle
 </match>
 ```
 
-### azure_storage_account (Required)
+### `azure_storage_account` (Required)
 
 Your Azure Storage Account Name. This can be retrieved from Azure Management portal.
 
-### azure_storage_access_key (Required)
+### `azure_storage_access_key` or `azure_storage_sas_token` (Required)
 
-Your Azure Storage Access Key (Primary or Secondary). This also can be retrieved from Azure Management portal.
+Used Azure Storage Account Access Key (Primary or Secondary) or shared access signature (SAS) token,
+which also can be retrieved from Azure Management portal.
 
-### azure_container (Required)
+### `azure_container` (Required)
 
 Azure Storage Container name
 
-### auto_create_container
+### `auto_create_container`
 
 This plugin creates the Azure container if it does not already exist exist when you set 'auto_create_container' to true.
 The default value is `true`
 
-### azure_object_key_format
+### `azure_object_key_format`
 
 The format of Azure Storage object keys. You can use several built-in variables:
 

--- a/lib/fluent/plugin/out_azure-storage-append-blob.rb
+++ b/lib/fluent/plugin/out_azure-storage-append-blob.rb
@@ -20,6 +20,7 @@ module Fluent
       config_param :path, :string, :default => ""
       config_param :azure_storage_account, :string, :default => nil
       config_param :azure_storage_access_key, :string, :default => nil, :secret => true
+      config_param :azure_storage_sas_token, :string, :default => nil, :secret => true
       config_param :azure_container, :string, :default => nil
       config_param :azure_object_key_format, :string, :default => "%{path}%{time_slice}-%{index}.log"
       config_param :auto_create_container, :bool, :default => true
@@ -67,7 +68,17 @@ module Fluent
       def start
         super
   
-        @bs = Azure::Storage::Blob::BlobService.create(storage_account_name: @azure_storage_account, storage_access_key: @azure_storage_access_key)
+        @bs_params = {storage_account_name: @azure_storage_account}
+
+        if !@azure_storage_access_key.nil?
+          @bs_params.merge!({storage_access_key: @azure_storage_access_key})
+        end
+
+        if !@azure_storage_sas_token.nil?
+          @bs_params.merge!({storage_sas_token: @azure_storage_sas_token})
+        end
+
+        @bs = Azure::Storage::Blob::BlobService.create(@bs_params)
   
         ensure_container
 


### PR DESCRIPTION
New `azure_storage_sas_token` fluent plugin parameter added, which could be used instead of `azure_storage_access_key` to get access to Azure storage account.